### PR TITLE
PHP Storm is now supported

### DIFF
--- a/source/_partials/status.blade.php
+++ b/source/_partials/status.blade.php
@@ -49,10 +49,7 @@ $categories = [
         'Tinkerwell' => 'yes',
         'Sublime Text' => 'yes',
         'VS Code' => 'yes',
-        'PHPStorm' => [
-            'link' => 'https://youtrack.jetbrains.com/issue/JBR-2526',
-            'status' => 'rosetta',
-        ],
+        'PHPStorm' => 'yes',
         'TablePlus' => 'yes',
         'DBngin' => 'unsure',
         'GitHub Desktop' => 'yes',


### PR DESCRIPTION
PHP Storm is now m1 compatible [See Blogpost](https://blog.jetbrains.com/phpstorm/2020/12/phpstorm-2020-3-1-is-released/)