### PR TITLE
Set Status of Redis to Yes

### DIFF
--- a/source/_partials/status.blade.php
+++ b/source/_partials/status.blade.php
@@ -29,19 +29,18 @@ $categories = [
         'oh-my-zsh' => 'yes',
         'Homebrew Redis' => [
             'link' => '#blog-redis-2',
-            'status' => 'no',
-            'details' => 'You can *sort of* make it work: `brew reinstall redis -s`, then run `sudo redis-server` every time you need Redis.'
+            'status' => 'yes',
         ],
         'Redis' => [
             'link' => '#blog-redis',
-            'status' => 'no',
+            'status' => 'yes',
         ],
         'MySQL' => 'yes',
         'PostgreSQL' => 'yes',
         'memcached' => 'yes',
         'PECL' => 'yes',
         'pecl install mongodb' => 'unsure',
-        'pecl install redis' => 'unsure',
+        'pecl install redis' => 'yes',
         'Vagrant' => 'unsure',
     ],
     'Common macOS tools used by Laravel developers' => [

--- a/source/_partials/status.blade.php
+++ b/source/_partials/status.blade.php
@@ -27,14 +27,8 @@ $categories = [
         'npm' => 'yes',
         'Lambo' => 'yes',
         'oh-my-zsh' => 'yes',
-        'Homebrew Redis' => [
-            'link' => '#blog-redis-2',
-            'status' => 'yes',
-        ],
-        'Redis' => [
-            'link' => '#blog-redis',
-            'status' => 'yes',
-        ],
+        'Homebrew Redis' => 'yes',
+        'Redis' => 'yes',
         'MySQL' => 'yes',
         'PostgreSQL' => 'yes',
         'memcached' => 'yes',


### PR DESCRIPTION
As of v6.0.10, Redis starts without running `sudo redis-server` on M1 Machines.
See: https://github.com/redis/redis/releases/tag/6.0.10

- https://github.com/redis/redis/pull/8150
- https://github.com/redis/redis/pull/8088

~~(Didn't know if the `link` keys should also be removed)~~